### PR TITLE
Replace CheckFileSignature with check_iso_signature

### DIFF
--- a/src/writing/flash_usb.py
+++ b/src/writing/flash_usb.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from src.writing.check_file_sig import _is_removable_device, _resolve_device_node
-from src.writing.check_file_sig import CheckFileSignature
+from src.writing.check_file_sig import check_iso_signature
 
 def FlashUSB(iso_path, usb_mount_path) -> bool:
     # Resolve the device node from the mount path — dd must target the
@@ -23,7 +23,7 @@ def FlashUSB(iso_path, usb_mount_path) -> bool:
     print(f"Flashing USB with command: {' '.join(dd_args)}")
 
     try:
-        if CheckFileSignature(iso_path):
+        if check_iso_signature(iso_path):
             subprocess.run(dd_args, check=True)
             print(f"Successfully flashed {iso_path} to {raw_device}")
             return True


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure USB flashing uses the updated ISO signature verification function before writing the image.