### PR TITLE
put gui.py in proper folder

### DIFF
--- a/src/gui/gui.py
+++ b/src/gui/gui.py
@@ -2,6 +2,7 @@ import sys
 import json
 import urllib.parse
 import webbrowser
+from pathlib import Path
 from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, 
                              QHBoxLayout, QGridLayout, QLabel, QComboBox, 
                              QPushButton, QProgressBar, QCheckBox, 
@@ -9,7 +10,13 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QLineEdit, QFrame, QStatusBar, QToolButton, QSpacerItem)
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QFont
-import states
+
+# gets imports from /drives
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.drives import states
+
 
 class LogWindow(QDialog):
     def __init__(self):

--- a/src/gui/start_gui.py
+++ b/src/gui/start_gui.py
@@ -2,6 +2,11 @@ import subprocess
 import json
 import sys
 import urllib.parse
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
 from src.drives.find_usb import find_usb
 
 def launch_gui_with_usb_data() -> None:
@@ -12,7 +17,8 @@ def launch_gui_with_usb_data() -> None:
     encoded_data = urllib.parse.quote(usb_json)
 
     try:
-        subprocess.run([sys.executable, "src/drives/gui.py", encoded_data], check=True)
+        gui_path = Path(__file__).resolve().with_name("gui.py")
+        subprocess.run([sys.executable, str(gui_path), encoded_data], check=True)
     except FileNotFoundError as e:
         print(f"Failed to launch GUI: executable or script not found: {e}")
         sys.exit(1)
@@ -21,4 +27,8 @@ def launch_gui_with_usb_data() -> None:
         sys.exit(e.returncode or e)
     except Exception as e:
         print(f"Unexpected error while launching GUI: {e}")
-        sys.exit(1)    
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    launch_gui_with_usb_data()


### PR DESCRIPTION
erm ;-; stawp ugh lame issue :3 put gui.py into the gui folder along with editing start_gui.py to start gui.py from gui. ermmm you can now use imports from src x3

## Summary by Sourcery

Relocate the GUI entrypoint into the gui package and update the launcher to execute it from its new location while supporting package-style imports.

Enhancements:
- Update the GUI launcher to resolve and execute the gui.py script from the gui package using pathlib.
- Adjust gui.py imports to use the src.drives.states module with a fallback for direct execution paths.