### PR TITLE
Added checksha function & tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Python
 __pycache__/
+.pytest_cache/
+tests/__pycache__
 *.py[cod]
 *.pyo
 *.pyd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ dependencies = [
     "pyqt6>=6.10.2",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+]
+
 [project.gui-scripts]
 rufus_py = "rufus_py.__main__:main"
 [build-system]

--- a/src/rufus_py/writing/check_file_sig.py
+++ b/src/rufus_py/writing/check_file_sig.py
@@ -1,6 +1,14 @@
 import psutil
+import hashlib
 from pathlib import Path
 import os
+
+
+def _is_valid_sha256_hex(hash_value: str) -> bool:
+    normalized = hash_value.strip().lower()
+    if len(normalized) != 64:
+        return False
+    return all(char in "0123456789abcdef" for char in normalized)
 
 def check_iso_signature(file_path: str) -> bool:
     """
@@ -12,7 +20,7 @@ def check_iso_signature(file_path: str) -> bool:
     """
     p = Path(file_path)
     if not p.is_file():
-        print(f"Error: {file_path} is not a valid file.")
+        print(f"Error: {file_path} is not a valid file. :(")
         return False
 
     try:
@@ -20,7 +28,7 @@ def check_iso_signature(file_path: str) -> bool:
             f.seek(32768)
             data = f.read(7)
             if len(data) < 7:
-                print(f"Error: {file_path} is too small to contain a valid PVD.")
+                print(f"Error: {file_path} is too small to contain a valid PVD. :(")
                 return False
             
             vd_type, ident, version = data[0], data[1:6], data[6]
@@ -29,14 +37,10 @@ def check_iso_signature(file_path: str) -> bool:
                 return True
             
             else:
-                print(f"Error: {file_path} does not have a valid ISO9660 PVD signature.")
+                print(f"Error: {file_path} does not have a valid ISO9660 PVD signature. :(")
                 return False
     except OSError as err:
-        print(f"Error reading {file_path}: {err}")
-        # no need to return here since we will return False at the end
-        # log err instead, same thing for Exception
-    except Exception as err:
-        print(f"Unexpected error: {err}")
+        print(f"Error reading {file_path}: {err} :(")
     
 
     return False
@@ -74,3 +78,41 @@ def _resolve_device_node(usb_mount_path: str) -> str | None:
         if os.path.normpath(part.mountpoint) == normalized:
             return _parent_block_device(part.device) or part.device
     return None
+
+# sha256 sum checking
+
+def check_sha256(file_path: str, expected_hash: str) -> bool:
+    """Check the SHA256 hash of a file against an expected value."""
+
+
+    # always check if file even exists b4 running anything else, no need to waste time calculating hash if file is not even there
+    p = Path(file_path)
+    if not p.is_file():
+        print(f"Error: {file_path} is not a valid file. :( ")
+        return False
+
+    normalized_expected_hash = expected_hash.strip().lower()
+    if not _is_valid_sha256_hex(normalized_expected_hash):
+        print("Error: expected SHA256 hash must be exactly 64 hexadecimal characters.")
+        return False
+
+
+    sha256 = hashlib.sha256()
+    try:
+        with p.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                sha256.update(chunk)
+        calculated_hash = sha256.hexdigest()
+        if calculated_hash == normalized_expected_hash:
+            print(f"SHA256 hash matches for {file_path}")
+            return True
+        else:
+            print(f"SHA256 hash mismatch for {file_path}: expected {normalized_expected_hash}, got {calculated_hash}")
+            print("You should not flash this ISO file, it may be corrupted or tampered with. :(")
+            return False
+    except OSError as err:
+        print(f"Error reading {file_path}: {err} :(")
+
+    return False
+# to the person that reads this: may you have a good day <3 
+# love, koyo

--- a/tests/HowToRunTests.md
+++ b/tests/HowToRunTests.md
@@ -1,0 +1,37 @@
+# How to run tests
+1. Activate `.venv` and install `pytest`, plus any other required dependencies for the project.
+2. With the correct interpreter, run the tests:
+
+```sh
+python -m pytest -q
+```
+
+If your virtual environment is not activated, run:
+
+```sh
+/home/kero/Documents/Projects/Rufus-Py-Dev/.venv/bin/python -m pytest -q
+```
+
+To run a single test file:
+
+```sh
+python -m pytest tests/test_check_file_sig.py -q
+```
+
+3. The output will show which tests passed and failed.
+4. Update tests as needed, but never intentionally make a test fail.
+
+# How to make your own tests
+
+1. Create a new file in the `tests/` directory with a name that starts with `test_` and ends with `.py` (for example, `test_my_feature.py`).
+2. Import the necessary modules and write test functions that start with `test_` (for example, `test_my_feature_functionality`).
+3. Use assertions to compare expected and actual outcomes (for example, `assert my_function() == expected_result`).
+4. Save the file and run the tests using the command above.
+
+# Important Notes
+
+- Write meaningful test cases that cover different scenarios for the function(s) you are testing.
+- If you need to change an existing test, explain the change and reason explicitly in your PR. Changes (NOT ADDITIONAL TESTS) to already-defined test files without proper reasoning may be immediately rejected.
+- If your PR is rejected for missing reasoning, no worries. resubmit with a clear explanation.
+- If you add a new feature, add tests for it. If the function is in a new source file, create a matching test file in `tests/`. If the function is in an existing source file, add tests to the corresponding existing test file. Example: if you add a function in `check_file_sig.py`, add its tests in `test_check_file_sig.py`.
+- Have questions? DM me on Discord (`_kerr0`) or open an issue in the repo. For contributors, please forward test-related issues to me. I made these tests, so I likely know them best and I’m happy to help ^^

--- a/tests/test_check_file_sig.py
+++ b/tests/test_check_file_sig.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+import hashlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from rufus_py.writing.check_file_sig import check_iso_signature, check_sha256
+
+
+def test_check_sha256_returns_false_when_file_does_not_exist(tmp_path: Path) -> None:
+    missing_file = tmp_path / "missing.iso"
+    assert check_sha256(str(missing_file), "abc") is False
+
+
+def test_check_sha256_returns_true_for_matching_hash(tmp_path: Path) -> None:
+    iso_file = tmp_path / "sample.iso"
+    content = b"rufus-py test content"
+    iso_file.write_bytes(content)
+
+    expected_hash = hashlib.sha256(content).hexdigest()
+
+    assert check_sha256(str(iso_file), expected_hash) is True
+
+
+def test_check_sha256_accepts_case_insensitive_expected_hash(tmp_path: Path) -> None:
+    iso_file = tmp_path / "sample.iso"
+    content = b"rufus-py test content"
+    iso_file.write_bytes(content)
+
+    expected_hash_upper = hashlib.sha256(content).hexdigest().upper()
+
+    assert check_sha256(str(iso_file), expected_hash_upper) is True
+
+
+def test_check_sha256_accepts_expected_hash_with_whitespace(tmp_path: Path) -> None:
+    iso_file = tmp_path / "sample.iso"
+    content = b"rufus-py test content"
+    iso_file.write_bytes(content)
+
+    expected_hash_with_spaces = f"  {hashlib.sha256(content).hexdigest()}\n"
+
+    assert check_sha256(str(iso_file), expected_hash_with_spaces) is True
+
+
+def test_check_sha256_returns_false_for_mismatched_hash(tmp_path: Path) -> None:
+    iso_file = tmp_path / "sample.iso"
+    iso_file.write_bytes(b"rufus-py test content")
+
+    wrong_hash = "0" * 64
+
+    assert check_sha256(str(iso_file), wrong_hash) is False
+
+
+def test_check_sha256_returns_false_for_invalid_hash_length(tmp_path: Path) -> None:
+    iso_file = tmp_path / "sample.iso"
+    iso_file.write_bytes(b"rufus-py test content")
+
+    assert check_sha256(str(iso_file), "abc123") is False
+
+
+def test_check_sha256_returns_false_for_non_hex_hash(tmp_path: Path) -> None:
+    iso_file = tmp_path / "sample.iso"
+    iso_file.write_bytes(b"rufus-py test content")
+
+    assert check_sha256(str(iso_file), "g" * 64) is False
+
+
+def test_check_iso_signature_returns_false_when_file_does_not_exist(tmp_path: Path) -> None:
+    missing_file = tmp_path / "missing.iso"
+    assert check_iso_signature(str(missing_file)) is False
+
+
+def test_check_iso_signature_returns_false_when_file_too_small(tmp_path: Path) -> None:
+    iso_file = tmp_path / "small.iso"
+    iso_file.write_bytes(b"tiny")
+
+    assert check_iso_signature(str(iso_file)) is False
+
+
+def test_check_iso_signature_returns_true_for_valid_pvd(tmp_path: Path) -> None:
+    iso_file = tmp_path / "valid.iso"
+    payload = bytearray(32768 + 7)
+    payload[32768] = 0x01
+    payload[32769:32774] = b"CD001"
+    payload[32774] = 0x01
+    iso_file.write_bytes(bytes(payload))
+
+    assert check_iso_signature(str(iso_file)) is True
+
+
+def test_check_iso_signature_returns_false_for_invalid_pvd(tmp_path: Path) -> None:
+    iso_file = tmp_path / "invalid.iso"
+    payload = bytearray(32768 + 7)
+    payload[32768] = 0x02
+    payload[32769:32774] = b"CD001"
+    payload[32774] = 0x01
+    iso_file.write_bytes(bytes(payload))
+
+    assert check_iso_signature(str(iso_file)) is False
+
+
+

--- a/tests/test_find_usb.py
+++ b/tests/test_find_usb.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from rufus_py.drives import find_usb as find_usb_module
+
+
+def test_find_usb_returns_mount_to_label_mapping(monkeypatch) -> None:
+    user = "testuser"
+    mount_path = f"/media/{user}/MY_USB"
+
+    monkeypatch.setattr(find_usb_module.getpass, "getuser", lambda: user)
+    monkeypatch.setattr(
+        find_usb_module.os.path,
+        "exists",
+        lambda p: p in {"/media", f"/media/{user}", mount_path},
+    )
+    monkeypatch.setattr(
+        find_usb_module.os.path,
+        "isdir",
+        lambda p: p in {"/media", f"/media/{user}", mount_path},
+    )
+    monkeypatch.setattr(
+        find_usb_module.os,
+        "listdir",
+        lambda p: ["MY_USB"] if p == f"/media/{user}" else [],
+    )
+    monkeypatch.setattr(
+        find_usb_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint=mount_path, device="/dev/sdb1")],
+    )
+    monkeypatch.setattr(
+        find_usb_module.subprocess,
+        "check_output",
+        lambda *args, **kwargs: "RUFUS_USB\n",
+    )
+
+    result = find_usb_module.find_usb()
+    assert result == {mount_path: "RUFUS_USB"}
+
+
+def test_find_usb_falls_back_to_dir_name_when_lsblk_fails(monkeypatch) -> None:
+    user = "testuser"
+    mount_path = f"/media/{user}/NO_LABEL"
+
+    monkeypatch.setattr(find_usb_module.getpass, "getuser", lambda: user)
+    monkeypatch.setattr(
+        find_usb_module.os.path,
+        "exists",
+        lambda p: p in {"/media", f"/media/{user}", mount_path},
+    )
+    monkeypatch.setattr(
+        find_usb_module.os.path,
+        "isdir",
+        lambda p: p in {"/media", f"/media/{user}", mount_path},
+    )
+    monkeypatch.setattr(
+        find_usb_module.os,
+        "listdir",
+        lambda p: ["NO_LABEL"] if p == f"/media/{user}" else [],
+    )
+    monkeypatch.setattr(
+        find_usb_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint=mount_path, device="/dev/sdc1")],
+    )
+
+    def raise_lsblk_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd="lsblk")
+
+    monkeypatch.setattr(find_usb_module.subprocess, "check_output", raise_lsblk_error)
+
+    result = find_usb_module.find_usb()
+    assert result == {mount_path: "NO_LABEL"}
+
+
+def test_find_dn_returns_matching_device_node(monkeypatch) -> None:
+    user = "testuser"
+    mount_path = f"/media/{user}/FLASH"
+
+    monkeypatch.setattr(find_usb_module.getpass, "getuser", lambda: user)
+    monkeypatch.setattr(
+        find_usb_module.os.path,
+        "exists",
+        lambda p: p in {"/media", f"/media/{user}", mount_path},
+    )
+    monkeypatch.setattr(
+        find_usb_module.os.path,
+        "isdir",
+        lambda p: p in {"/media", f"/media/{user}", mount_path},
+    )
+    monkeypatch.setattr(
+        find_usb_module.os,
+        "listdir",
+        lambda p: ["FLASH"] if p == f"/media/{user}" else [],
+    )
+    monkeypatch.setattr(
+        find_usb_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint=mount_path, device="/dev/sdd1")],
+    )
+
+    assert find_usb_module.find_DN() == "/dev/sdd1"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from rufus_py.drives import formatting
+
+
+def _setup_common_monkeypatch(monkeypatch) -> None:
+    monkeypatch.setattr(formatting, "cluster", lambda: ("4096", "512", "8"))
+    monkeypatch.setattr(formatting.fu, "find_usb", lambda: {"/media/testuser/USB": "USB"})
+    monkeypatch.setattr(formatting.fu, "find_DN", lambda: "/dev/sdb1")
+
+
+@pytest.mark.parametrize(
+    ("fs_type", "expected_tool"),
+    [
+        (0, "mkfs.ntfs"),
+        (1, "mkfs.vfat"),
+        (2, "mkfs.exfat"),
+        (3, "mkfs.ext4"),
+    ],
+)
+def test_dskformat_runs_expected_mkfs_command(monkeypatch, fs_type: int, expected_tool: str) -> None:
+    _setup_common_monkeypatch(monkeypatch)
+    monkeypatch.setattr(formatting.states, "currentFS", fs_type)
+
+    calls = []
+
+    def fake_run(cmd, check=True):
+        calls.append(cmd)
+
+    monkeypatch.setattr(formatting.subprocess, "run", fake_run)
+
+    formatting.dskformat()
+
+    assert len(calls) == 1
+    assert calls[0][0] == "pkexec"
+    assert calls[0][1] == expected_tool
+
+
+def test_dskformat_calls_unexpected_for_unknown_fs(monkeypatch) -> None:
+    _setup_common_monkeypatch(monkeypatch)
+    monkeypatch.setattr(formatting.states, "currentFS", 99)
+
+    called = {"unexpected": False}
+
+    def fake_unexpected():
+        called["unexpected"] = True
+
+    monkeypatch.setattr(formatting, "unexpected", fake_unexpected)
+    monkeypatch.setattr(formatting.subprocess, "run", lambda *args, **kwargs: None)
+
+    formatting.dskformat()
+
+    assert called["unexpected"] is True

--- a/tests/test_get_usb_info.py
+++ b/tests/test_get_usb_info.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from rufus_py.drives import get_usb_info as get_usb_info_module
+
+
+def test_get_usb_info_returns_empty_when_mount_not_found(monkeypatch) -> None:
+    monkeypatch.setattr(
+        get_usb_info_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint="/mnt/other", device="/dev/sdb1")],
+    )
+
+    assert get_usb_info_module.GetUSBInfo("/media/testuser/USB") == {}
+
+
+def test_get_usb_info_returns_expected_dictionary(monkeypatch) -> None:
+    mount_path = "/media/testuser/USB"
+    device_node = "/dev/sdb1"
+
+    monkeypatch.setattr(
+        get_usb_info_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint=mount_path, device=device_node)],
+    )
+
+    def fake_check_output(cmd, text=True, timeout=5):
+        if cmd[-2:] == ["SIZE", device_node]:
+            return str(16 * 1024**3)
+        if cmd[-2:] == ["LABEL", device_node]:
+            return "MYUSB\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(get_usb_info_module.subprocess, "check_output", fake_check_output)
+
+    result = get_usb_info_module.GetUSBInfo(mount_path)
+    assert result == {
+        "device_node": device_node,
+        "label": "MYUSB",
+        "mount_path": mount_path,
+    }
+
+
+def test_get_usb_info_uses_mount_basename_when_label_is_empty(monkeypatch) -> None:
+    mount_path = "/media/testuser/NO_LABEL"
+    device_node = "/dev/sdc1"
+
+    monkeypatch.setattr(
+        get_usb_info_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint=mount_path, device=device_node)],
+    )
+
+    def fake_check_output(cmd, text=True, timeout=5):
+        if cmd[-2:] == ["SIZE", device_node]:
+            return str(8 * 1024**3)
+        if cmd[-2:] == ["LABEL", device_node]:
+            return "\n"
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(get_usb_info_module.subprocess, "check_output", fake_check_output)
+
+    result = get_usb_info_module.GetUSBInfo(mount_path)
+    assert result["label"] == "NO_LABEL"
+
+
+def test_get_usb_info_returns_empty_when_lsblk_fails(monkeypatch) -> None:
+    mount_path = "/media/testuser/USB"
+    device_node = "/dev/sdb1"
+
+    monkeypatch.setattr(
+        get_usb_info_module.psutil,
+        "disk_partitions",
+        lambda: [SimpleNamespace(mountpoint=mount_path, device=device_node)],
+    )
+
+    def raise_lsblk_error(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd="lsblk")
+
+    monkeypatch.setattr(get_usb_info_module.subprocess, "check_output", raise_lsblk_error)
+
+    assert get_usb_info_module.GetUSBInfo(mount_path) == {}


### PR DESCRIPTION
This commit brings along a new function in check_file_sig.py to check SHA256 automatically, test cases were added for possible tests i could think of along side instructions to make/add tests.

translated:
haiii :3 me puts function in `check_file_sig.py` to check sha256 auwutomatically xPP, test pawses were added for pawsible tests puppy me could think of w/ instructions to make or add tests x3

## Summary by Sourcery

Add SHA256 checksum verification for ISO files and introduce a basic test suite for drive handling and file signature utilities.

New Features:
- Introduce a check_sha256 helper to validate a file's SHA256 hash against an expected value.

Enhancements:
- Improve error messaging and validation for ISO signature and SHA256 checks, including basic SHA256 format validation.
- Add optional development dependency set for running tests with pytest.

Documentation:
- Add contributor-facing documentation on how to run and write tests using pytest.

Tests:
- Add tests for USB drive discovery, USB info retrieval, disk formatting selection, ISO signature validation, and the new SHA256 check helper.