### PR TITLE
Handle empty mount_dict in formatting.py

### DIFF
--- a/src/rufus_py/drives/formatting.py
+++ b/src/rufus_py/drives/formatting.py
@@ -5,9 +5,14 @@ from rufus_py.drives import states
 from rufus_py.drives import find_usb as fu
 #######
 
+
 mount_dict = fu.find_usb()  # GETS THE FIRST KEY FOR NOW
-mount = next(iter(mount_dict))  # IMPORT THE INITIAL MOUNT POINT
-drive = fu.find_DN() # IMPORTS DRIVE NODE
+if mount_dict:
+    mount = next(iter(mount_dict))  # IMPORT THE INITIAL MOUNT POINT
+    drive = fu.find_DN() # IMPORTS DRIVE NODE
+else:
+    mount=None
+    drive=None
 
 def pkexecNotFound():
     print("Error: The command pkexec or labeling software was not found on your system.")


### PR DESCRIPTION
Add check for mount_dict before accessing its elements.

## Summary by Sourcery

Bug Fixes:
- Avoid crashes by checking for an empty mount dictionary before deriving the mount point and drive node.