### PR TITLE
make flashing Linux ISOs work i think

### DIFF
--- a/src/rufus_py/drives/formatting.py
+++ b/src/rufus_py/drives/formatting.py
@@ -49,21 +49,22 @@ def pkexecNotFound():
 def FormatFail():
     print("Error: Formatting failed. Was the password correct? Is the drive unmounted?")
 
+def UnmountFail():
+    print("Error: Unmounting failed. Perhaps either the drive was already unmounted or is in use.")
 
 def unexpected():
     print("An unexpected error occurred")
 
 
 # UNMOUNT FUNCTION
-def unmount():
-    _, drive, _ = _get_mount_and_drive()
+def unmount(drive: str = None):
     if not drive:
         print("Error: No drive node found. Cannot unmount.")
         return
     try:
         subprocess.run(["umount", drive], check=True)
     except subprocess.CalledProcessError:
-        FormatFail()
+        UnmountFail()
     except Exception as e:
         print(f"(UMNTFUNC) DEBUG: Unexpected error type: {type(e).__name__}")
         print(f"DEBUG: Error message: {e}")

--- a/src/rufus_py/gui/gui.py
+++ b/src/rufus_py/gui/gui.py
@@ -1,5 +1,6 @@
 import sys
 import json
+from glob import glob
 import urllib.parse
 import webbrowser
 from pathlib import Path
@@ -130,18 +131,19 @@ class FlashWorker(QThread):
     finished = pyqtSignal(bool)
     progress = pyqtSignal(str)
     
-    def __init__(self, iso_path: str, mount_path: str):
+    def __init__(self, iso_path: str, device_node: str):
         super().__init__()
         self.iso_path = iso_path
-        self.mount_path = mount_path
+        self.device_node = device_node
     
     def run(self):
         try:
             self.progress.emit("Unmounting drive...")
-            fo.unmount()
+            for partition in glob(f"{self.device_node}*"):
+                fo.unmount(partition)
             
             self.progress.emit("Flashing ISO to device...")
-            result = FlashUSB(self.iso_path, self.mount_path)
+            result = FlashUSB(self.iso_path, self.device_node)
             
             if result:
                 self.progress.emit("Flashing complete!")
@@ -796,8 +798,8 @@ class Rufus(QMainWindow):
                 if not getattr(states, 'iso_path', '') or not Path(states.iso_path).exists():
                     QMessageBox.warning(self, "No Image", "Please select a valid installation file first.")
                     return
-                mount_path = self.get_selected_mount_path()
-                if not mount_path:
+                device_node = self.get_selected_mount_path()
+                if not device_node:
                     QMessageBox.warning(self, "No Device", "Please select a USB device first.")
                     return
                 
@@ -807,12 +809,12 @@ class Rufus(QMainWindow):
                 self.progress_bar.setFormat("Preparing...")
                 self.statusBar.showMessage("Flashing...", 0)
                 
-                self.flash_worker = FlashWorker(states.iso_path, mount_path)
+                self.flash_worker = FlashWorker(states.iso_path, device_node)
                 self.flash_worker.progress.connect(lambda msg: self.statusBar.showMessage(msg, 0))
                 self.flash_worker.finished.connect(self.on_flash_finished)
                 self.flash_worker.start()
                 
-                self.log_message(f"Starting flash process: {states.iso_path} -> {mount_path}")
+                self.log_message(f"Starting flash process: {states.iso_path} -> {device_node}")
             else: # OTHER METHODS NOT YET DONE
                 pass 
         elif states.image_option == 2: # ONLY FORMATTING

--- a/src/rufus_py/writing/flash_usb.py
+++ b/src/rufus_py/writing/flash_usb.py
@@ -15,20 +15,18 @@ def FormatFail():
 def unexpected():
     print(f"An unexpected error occurred")
 
-def FlashUSB(iso_path, usb_mount_path) -> bool:
+def FlashUSB(iso_path, raw_device) -> bool:
     # Resolve the device node from the mount path — dd must target the
     # raw device (e.g. /dev/sdb), not the mounted directory.
-    print(states.DN)
-    device_node = states.DN
-    print(device_node)
+    print(raw_device)
     # if not device_node:
     #     print(f"Could not resolve device node for mount path: {usb_mount_path}")
     #     return False
 
     # Strip the partition number so dd writes to the whole disk
     # raw_device = device_node.rstrip("0123456789")
-    raw_device = re.sub(r"[0-9]+$","",device_node) #using regex to get the raw device node
-    print(device_node, raw_device)
+    raw_device = re.sub(r"[0-9]+$","",raw_device) #using regex to get the raw device node
+    print(raw_device)
     
     try:
         if not check_iso_signature(iso_path):
@@ -64,7 +62,6 @@ def FlashUSB(iso_path, usb_mount_path) -> bool:
     #     return False
 
     try:
-        dd_args = ["dd", f"if={iso_path}", f"of={raw_device}", "bs=4M", "status=progress", "conv=fdatasync"]
         print(f"Flashing USB with command: {' '.join(dd_args)}")
     except FileNotFoundError:
         pkexecNotFound()


### PR DESCRIPTION
## Summary by Sourcery

Update Linux ISO flashing workflow to operate on raw device nodes instead of mount paths and improve unmount handling before flashing.

Bug Fixes:
- Use the selected device node rather than a mount path or global state when flashing USB devices, ensuring the correct drive is targeted.
- Unmount all partitions of the selected device before flashing to avoid mount-related failures.
- Handle unmount failures with a dedicated error path instead of reporting them as formatting errors.

Enhancements:
- Refine status and log messages to reflect device-based flashing operations.