### PR TITLE
added bad check function call on start process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "psutil>=7.2.2",
     "pyqt6>=6.10.2",
     "pyudev>=0.24.4",
-    "woeusb-ng>=0.2.12",
+    "woeusb-ng>=0.2.12"
 ]
 
 [project.optional-dependencies]

--- a/src/lufus/drives/formatting.py
+++ b/src/lufus/drives/formatting.py
@@ -161,7 +161,6 @@ def createextended():
 
 def checkdevicebadblock():
     """Check the device for bad blocks using badblocks.
-
     Requires the drive to be unmounted.  The number of passes is determined by
     states.check_bad (0 = 1 pass read-only, 1 = 2 passes read/write).
     """

--- a/src/lufus/gui/gui.py
+++ b/src/lufus/gui/gui.py
@@ -831,6 +831,11 @@ class lufus(QMainWindow):
         self.statusBar.showMessage("Ready", 0)
     
     def start_process(self):
+
+        # Bad blocks check
+        if states.check_bad == 0:
+            fo.checkdevicebadblock()
+
         states.DN = self.combo_device.currentData() or ""
         if states.image_option == 0: # WINDOWS
             if states.currentflash == 0: # iso mode


### PR DESCRIPTION
## Summary by Sourcery

Run a bad-blocks check when starting the flashing process and make a minor dependency/configuration cleanup.

New Features:
- Trigger a device bad-blocks check at the beginning of the start_process workflow when the corresponding option is enabled.

Enhancements:
- Clean up pyproject configuration formatting and remove an unnecessary blank line in the bad-block check helper.