### PR TITLE
Updated a french translation

### DIFF
--- a/src/lufus/gui/languages/Français.csv
+++ b/src/lufus/gui/languages/Français.csv
@@ -23,7 +23,7 @@ lbl_file_system,Système de fichiers
 lbl_flash_option,Option de flash
 lbl_cluster_size,Taille d'unité d'allocation
 combo_image_windows,Installation standard de Windows
-combo_image_linux,Installation Linux standard
+combo_image_linux,Installation standard de Linux
 combo_image_other,N'importe quelle installation (mode DD)
 combo_image_format,Mode formatage uniquement
 combo_partition_gpt,GPT


### PR DESCRIPTION
Standard windows install is installation standard de windows Though for some reason standard linux install was translated to installation linux standard So i changed it to installation standard de linux to match with its windows equivalent

(Was Lufus initially translated with Google or something?)

## Summary by Sourcery

Enhancements:
- Correct French wording for the standard Linux installation label to be consistent with the standard Windows installation label.