### PR TITLE
Enhance lufus.sh with dependency checks and pip upgrade

### DIFF
--- a/lufus.sh
+++ b/lufus.sh
@@ -2,7 +2,19 @@
 
 set -euo pipefail
 
+# Require sudo/root
+if [ "$EUID" -ne 0 ]; then
+    echo "usage: sudo ./lufus.sh"
+    exit 1
+fi
+
 VENV_DIR=".venv"
+
+# Ensure python exists
+if ! command -v python3 &> /dev/null; then
+    echo "python not found"
+    exit 1
+fi
 
 echo "Setting up virtual environment..."
 
@@ -14,16 +26,36 @@ fi
 # Activate venv
 source "$VENV_DIR/bin/activate"
 
-# Upgrade pip (optional but recommended)
-pip install --upgrade pip
-
 # Install Briefcase if not installed
 if ! pip show briefcase > /dev/null 2>&1; then
     echo "Installing Briefcase..."
+    pip install --upgrade pip
     pip install briefcase
 fi
+
+# Check system dependencies
+REQUIRED_CMDS=(
+    parted mkfs.vfat mkfs.ntfs mkfs.exfat mkfs.ext4
+    badblocks blockdev wimmountrw chntpw
+)
+
+MISSING=()
+
+for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! command -v "$cmd" &> /dev/null; then
+        MISSING+=("$cmd")
+    fi
+done
+# Print missing dependencies
+if [ ${#MISSING[@]} -ne 0 ]; then
+    echo "Missing system tools:"
+    printf ' - %s\n' "${MISSING[@]}"
+    echo "Install them before continuing."
+    exit 1
+fi
+
 
 echo "Running app..."
 
 # Run the app
-briefcase dev
+briefcase dev -r


### PR DESCRIPTION
Added checks for required system dependencies and ensured pip is upgraded before installing Briefcase.

## Summary by Sourcery

Add environment validation and dependency checks to the lufus.sh helper script before running the Briefcase dev environment.

New Features:
- Require the script to be run with sudo/root privileges before proceeding.
- Verify python3 is installed before creating and using the virtual environment.
- Check for required system tools (partitioning, filesystem, and Windows image utilities) and abort with a clear message if any are missing.

Enhancements:
- Upgrade pip only when Briefcase needs to be installed, and run the app via `briefcase dev` with an added refresh flag.