### PR TITLE
Fixed TOML and added MANIFEST.in for PKGBUILD compatibility

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include src/lufus/gui/themes *
+recursive-include src/lufus/gui/languages *
+recursive-include src/lufus/gui/assets *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,6 @@ license.file = "LICENSE"
 author = "Hog185"
 author_email = "example@example.com"
 
-[tool.uv_build]
-package-data = {"lufus" = ["gui/themes/*", "gui/languages/*", "gui/assets/*"]}
-
 [tool.briefcase.app.lufus]
 formal_name = "Lufus"
 description = "A rufus clone written in Python and designed to work with Linux."


### PR DESCRIPTION
## Summary by Sourcery

Adjust project packaging metadata and configuration for improved distribution compatibility.

Build:
- Update pyproject.toml metadata to use table-style license declaration and require Python 3.13 or newer.
- Add MANIFEST.in to control packaged files for compatibility with external packaging systems such as PKGBUILD.