### PR TITLE
ci: replace flake8 with ruff for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install psutil pytest flake8
+          pip install psutil pytest
 
       - name: Install package (no-deps to avoid GUI reqs)
         run: pip install -e . --no-deps
@@ -46,11 +46,22 @@ jobs:
             --ignore=src/lufus/drives/autodetect_usb.py \
             tests/
 
-      - name: Lint with flake8
-        run: |
-          flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics \
-            --exclude=src/lufus/gui,src/lufus/drives/autodetect_usb.py
-          flake8 src/ tests/ --count --max-line-length=120 --statistics --exit-zero \
-            --exclude=src/lufus/gui,src/lufus/drives/autodetect_usb.py
-
     continue-on-error: true
+
+  ruff_lint:
+    name: Ruff lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: 'check .'
+
+  ruff_format:
+    name: Ruff format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: 'format --check'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,3 +141,9 @@ dependencies = [
     "packaging",
     "platformdirs>=4.9.4"
 ]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E9", "F63", "F7", "F82"]


### PR DESCRIPTION
## Summary by Sourcery

Replace Flake8-based linting with Ruff for Python code quality checks.

Enhancements:
- Configure Ruff in pyproject.toml with project-specific line length and linting rule selection.

CI:
- Remove Flake8 linting from the main CI workflow and add dedicated jobs for Ruff linting and formatting checks.